### PR TITLE
Fixed bug getter reflection logic not being used to find property

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
     - "$HOME/.composer/cache"
 
 php:
-  - 7
+  - 7.2
 
 before_install:
    - composer self-update

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -56,8 +56,9 @@ class Generator
             $propertyInfoContext = $context['property_info_context'] ?? [];
 
             $writable = $this->propertyInfoExtractor->isWritable($className, $propertyName, $propertyInfoContext);
+            $readable = $this->propertyInfoExtractor->isReadable($className, $propertyName, $propertyInfoContext);
 
-            if (null === $writable || false === $writable) {
+            if ((null === $writable || false === $writable) && (null === $readable || false === $readable)) {
                 continue;
             }
 


### PR DESCRIPTION
The getter reflection logic was not used to fetch properties, meaning the script would only work if the classes had setters, even though that's by all means not always the case for simple models. This pull request fixes that and now uses the getter reflection logic.